### PR TITLE
Do not add app/controllers/concerns to paths

### DIFF
--- a/sitepress-rails/lib/sitepress/engine.rb
+++ b/sitepress-rails/lib/sitepress/engine.rb
@@ -6,12 +6,6 @@ module Sitepress
         app.paths["app/assets"].push config.site.root_path.join("assets")
         app.paths["app/views"].push config.site.root_path
       end
-
-      # Setup concerns paths for Rails 4 (doesn't automatically populate)
-      concerns_path = "app/controllers/concerns"
-      unless app.paths.keys.include?(concerns_path)
-        app.paths.add(concerns_path)
-      end
     end
 
     initializer "sitepress.configure" do |app|


### PR DESCRIPTION
Controller concerns are added to paths by default starting in Rails 4.0: https://github.com/rails/rails/commit/f6bbc3f582bfc16da3acc152c702b04102fcab81

Furthermore, the code removed in this PR causes `app/controllers/concerns` to *not* be included in `eagler_load_paths` under Rails 5.0. I believe this is the change in Rails 5 that makes this an issue: 

https://github.com/rails/rails/pull/18213/files#diff-fe18f3d1547d462665ccd5f7e540aa90L50

Let me know if you have any questions.