### PR TITLE
Update controller_layout for Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,12 @@
 language: ruby
 rvm:
-  - 2.4.0
-  - 2.3.0
-  - 2.2.0
-  - 2.1.0
+  - 2.6.0
+  - 2.5.0
 gemfile:
-  - gemfiles/rails_4.gemfile
   - gemfiles/rails_5.gemfile
-matrix:
-  exclude:
-  - rvm: 2.2.0
-    gemfile: gemfiles/rails_5.gemfile
-  - rvm: 2.1.0
-    gemfile: gemfiles/rails_5.gemfile
-bundler_args: --without appraisal
-before_install: gem install bundler -v 1.14.6
+  - gemfiles/rails_6.gemfile
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
+  - bundle config set without 'appraisal'
 script: bundle exec rake ci

--- a/Appraisals
+++ b/Appraisals
@@ -1,8 +1,8 @@
-appraise "rails-4" do
-  gem "rails", "4.2.8"
+appraise "rails-5" do
+  gem "rails", "~> 5.2.0"
+  gem "rails-controller-testing"
 end
 
-appraise "rails-5" do
-  gem "rails", "5.0.2"
-  gem "rails-controller-testing"
+appraise "rails-6" do
+  gem "rails", "6.0.3.2"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec path: "sitepress-core"
 gemspec path: "sitepress-rails"
 gemspec path: "sitepress-server"
 
-gem "appraisal", "~> 2.2.0"
+gem "appraisal", "~> 2.3.0"
 
 group :test do
   gem "simplecov"

--- a/benchmarks/rails_rendering_benchmark.rb
+++ b/benchmarks/rails_rendering_benchmark.rb
@@ -7,8 +7,7 @@ title "Rails requests for #{page_count} asset site"
 # Verifies that a non-200 response isn't mistaken as a valid benchmark.
 def get!(path)
   resp = get(path)
-  status, _, body = resp
-  fail "GET #{path.inspect} - HTTP #{status} resp\n---\n#{body.body}\n---" if status != 200
+  fail "GET #{path.inspect} - HTTP #{resp.status} resp\n---\n#{resp.body}\n---" if resp.status != 200
   resp
 end
 

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", "~> 2.2.0"
-gem "rails", "5.0.2"
+gem "appraisal", "~> 2.3.0"
+gem "rails", "~> 5.2.0"
 gem "rails-controller-testing"
 
 group :test do

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -2,8 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", "~> 2.2.0"
-gem "rails", "4.2.8"
+gem "appraisal", "~> 2.3.0"
+gem "rails", "6.0.3.2"
+gem "rails-controller-testing"
 
 group :test do
   gem "simplecov"

--- a/sitepress-cli/sitepress-cli.gemspec
+++ b/sitepress-cli/sitepress-cli.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "sitepress-server", spec.version
-  spec.add_runtime_dependency "thor", "~> 0.19.0"
+  spec.add_runtime_dependency "thor", "~> 0.20.0"
   spec.add_runtime_dependency "rack", ">= 1.0"
 end

--- a/sitepress-core/sitepress-core.gemspec
+++ b/sitepress-core/sitepress-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", ">= 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 

--- a/sitepress-rails/app/controllers/concerns/sitepress/site_pages.rb
+++ b/sitepress-rails/app/controllers/concerns/sitepress/site_pages.rb
@@ -62,16 +62,15 @@ module Sitepress
     # exposed via some really convoluted private methods inside of the various
     # versions of Rails, so I try my best to hack out the path to the layout below.
     def controller_layout
-      # Rails 4 and 5 expose the `_layout` via methods with different arity. Since
-      # I don't want to hard code the version, I'm detecting arity and hoping that Rails 6
-      # doesn't break this approach. If it does I'll probably have to get into the business
-      # of version detection.
       private_layout_method = self.method(:_layout)
-      layout = if private_layout_method.arity == 1 # Rails 5
-        private_layout_method.call current_page_rails_formats
-      else # Rails 4
-        private_layout_method.call
-      end
+      layout =
+        if Rails.version >= "6"
+          private_layout_method.call lookup_context, current_page_rails_formats
+        elsif Rails.version >= "5"
+          private_layout_method.call current_page_rails_formats
+        else
+          private_layout_method.call
+        end
 
       if layout.instance_of? String # Rails 4 and 5 return a string from above.
         layout

--- a/sitepress-rails/sitepress-rails.gemspec
+++ b/sitepress-rails/sitepress-rails.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.test_files = Dir["spec/**/*"]
 
-  spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "pry"
 

--- a/sitepress-rails/spec/dummy/app/models/application_record.rb
+++ b/sitepress-rails/spec/dummy/app/models/application_record.rb
@@ -1,3 +1,0 @@
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-end

--- a/sitepress-rails/spec/dummy/config/application.rb
+++ b/sitepress-rails/spec/dummy/config/application.rb
@@ -1,6 +1,8 @@
 require_relative 'boot'
 
-require 'rails/all'
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "sprockets/railtie"
 
 Bundler.require(*Rails.groups)
 require "sitepress-rails"

--- a/sitepress-rails/spec/dummy/config/environments/development.rb
+++ b/sitepress-rails/spec/dummy/config/environments/development.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.active_support.deprecation = :log
 
   # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
+  # config.active_record.migration_error = :page_load
 
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large

--- a/sitepress-rails/spec/dummy/config/environments/production.rb
+++ b/sitepress-rails/spec/dummy/config/environments/production.rb
@@ -74,5 +74,5 @@ Rails.application.configure do
   end
 
   # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
+  # config.active_record.dump_schema_after_migration = false
 end


### PR DESCRIPTION
Rails 6 added a `lookup_context` argument to the `_layout` method.
Fortunately, the controller already has a `lookup_context`, so we can
just pass that on.

@bradgessler I added a rails_6.gemfile, but all I did to it was bump Rails, so it might need further changes to actually work.