### PR TITLE
Introduce models to encapsulate pages as data

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Sitepress is a file-backed website content manager that can be embedded in popular web frameworks like Rails, run stand-alone, or be compiled into static sites. Its useful for marketing pages or small websites that you need to deploy within your web frameworks.
 
+It features:
+
+* Wide support for templates incuding Erb, Haml, Slim, and more.
+* Static site compilation to S3, Netlify, etc.
+* Embedable in Rails monoliths
+* Frontmatter
+* Page models
+* Helpers
+
 [![Build status](https://github.com/sitepress/sitepress/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/sitepress/sitepress/actions/workflows/test.yml) [![Code Climate](https://codeclimate.com/github/sitepress/sitepress/badges/gpa.svg)](https://codeclimate.com/github/sitepress/sitepress)
 
 ## Installation

--- a/sitepress-core/lib/sitepress/site.rb
+++ b/sitepress-core/lib/sitepress/site.rb
@@ -64,6 +64,10 @@ module Sitepress
       root_path.join("assets")
     end
 
+    def models_path
+      root_path.join("models")
+    end
+
     # Quick and dirty way to manipulate resources in the site without
     # creating classes that implement the #process_resources method.
     #

--- a/sitepress-rails/lib/sitepress/engine.rb
+++ b/sitepress-rails/lib/sitepress/engine.rb
@@ -24,6 +24,7 @@ module Sitepress
       app.paths["app/assets"].push site.assets_path.expand_path
       app.paths["app/views"].push site.root_path.expand_path
       app.paths["app/views"].push site.pages_path.expand_path
+      app.paths["app/models"].push site.models_path.expand_path
     end
 
     # Configure sprockets paths for the site.

--- a/sitepress-rails/lib/sitepress/model.rb
+++ b/sitepress-rails/lib/sitepress/model.rb
@@ -1,0 +1,43 @@
+module Sitepress
+  class Model
+    attr_reader :page
+
+    delegate \
+      :request_path,
+      :data,
+      :body,
+        to: :page
+
+    def initialize(page)
+      @page = page
+    end
+
+    class << self
+      def all(glob: self.path)
+        Enumerator.new do |y|
+          site.glob(glob).each { |page| y << new(page) }
+        end
+      end
+
+      def attr_data(*keys, default: nil)
+        keys.each do |key|
+          define_method key do
+            data.fetch key, default
+          end
+        end
+      end
+
+      def path(path=nil)
+        if path
+          @path = path
+        else
+          @path
+        end
+      end
+
+      def site
+        Sitepress.site
+      end
+    end
+  end
+end

--- a/sitepress-rails/lib/sitepress/model.rb
+++ b/sitepress-rails/lib/sitepress/model.rb
@@ -13,6 +13,11 @@ module Sitepress
       @page = page
     end
 
+    # Treat as equal if the resource and model class are the same.
+    def ==(model)
+      self.page == model.page and self.class == model.class
+    end
+
     class << self
       def collection(name = Models::Collection::DEFAULT_NAME, **kwargs)
         define_singleton_method name do

--- a/sitepress-rails/lib/sitepress/model.rb
+++ b/sitepress-rails/lib/sitepress/model.rb
@@ -1,4 +1,5 @@
 module Sitepress
+  # Wraps a page in a class, which makes it much easier to decorate and validate.
   class Model
     attr_reader :page
 
@@ -13,9 +14,9 @@ module Sitepress
     end
 
     class << self
-      def all(glob: self.path)
-        Enumerator.new do |y|
-          site.glob(glob).each { |page| y << new(page) }
+      def collection(name = Models::Collection::DEFAULT_NAME, **kwargs)
+        define_singleton_method name do
+          Models::Collection.new model: self, site: site, **kwargs
         end
       end
 
@@ -24,14 +25,6 @@ module Sitepress
           define_method key do
             self.data.fetch key.to_s, default
           end
-        end
-      end
-
-      def path(path=nil)
-        if path
-          @path = path
-        else
-          @path
         end
       end
 

--- a/sitepress-rails/lib/sitepress/model.rb
+++ b/sitepress-rails/lib/sitepress/model.rb
@@ -20,6 +20,22 @@ module Sitepress
         end
       end
 
+      # Wraps a page in a class if given a string that represents the path or
+      # a page object itself.
+      def get(page)
+        case page
+        when Model
+          page
+        when String
+          new site.get page
+        when Sitepress::Resource
+          new page
+        else
+          raise ModelNotFoundError, "#{self.inspect} could not find #{page.inspect}"
+        end
+      end
+      alias :find :get
+
       def attr_data(*keys, default: nil)
         keys.each do |key|
           define_method key do

--- a/sitepress-rails/lib/sitepress/model.rb
+++ b/sitepress-rails/lib/sitepress/model.rb
@@ -22,7 +22,7 @@ module Sitepress
       def attr_data(*keys, default: nil)
         keys.each do |key|
           define_method key do
-            data.fetch key, default
+            self.data.fetch key.to_s, default
           end
         end
       end

--- a/sitepress-rails/lib/sitepress/model.rb
+++ b/sitepress-rails/lib/sitepress/model.rb
@@ -19,10 +19,17 @@ module Sitepress
     end
 
     class << self
-      def collection(name = Models::Collection::DEFAULT_NAME, **kwargs)
+      # Defines a class method that may be called later to return a
+      # collection of objects.
+      def collection(name = Models::Collection::DEFAULT_NAME, glob:, **kwargs)
         define_singleton_method name do
-          Models::Collection.new model: self, site: site, **kwargs
+          self.glob glob, **kwargs
         end
+      end
+
+      # Adhoc querying of models via `Model.glob("foo/bar").all`
+      def glob(glob, **kwargs)
+        Models::Collection.new model: self, site: site, glob: glob, **kwargs
       end
 
       # Wraps a page in a class if given a string that represents the path or

--- a/sitepress-rails/lib/sitepress/models/collection.rb
+++ b/sitepress-rails/lib/sitepress/models/collection.rb
@@ -1,0 +1,34 @@
+module Sitepress
+  module Models
+    # Everything needed to iterate over a set of pages from a glob and wrap
+    # them in a model so they are returned as a sensible enumerable.
+    class Collection
+      include Enumerable
+
+      # Page models will have `PageModel.all` method defined by default.
+      DEFAULT_NAME = :all
+
+      # Iterate over all pages in the site by default.
+      DEFAULT_GLOB = "**/*.*".freeze
+
+      attr_reader :model, :glob, :site
+
+      def initialize(model:, site:, glob: DEFAULT_GLOB)
+        @model = model
+        @glob = glob
+        @site = site
+      end
+
+      def pages
+        site.glob glob
+      end
+
+      # Wraps each page in a model object.
+      def each
+        pages.each do |page|
+          yield model.new page
+        end
+      end
+    end
+  end
+end

--- a/sitepress-rails/lib/sitepress/rails.rb
+++ b/sitepress-rails/lib/sitepress/rails.rb
@@ -3,6 +3,9 @@ require "sitepress-core"
 module Sitepress
   autoload :Compiler,                 "sitepress/compiler"
   autoload :Model,                    "sitepress/model"
+  module Models
+    autoload :Collection,             "sitepress/models/collection"
+  end
   autoload :RailsConfiguration,       "sitepress/rails_configuration"
   module Renderers
     autoload :Controller,             "sitepress/renderers/controller"

--- a/sitepress-rails/lib/sitepress/rails.rb
+++ b/sitepress-rails/lib/sitepress/rails.rb
@@ -2,6 +2,7 @@ require "sitepress-core"
 
 module Sitepress
   autoload :Compiler,                 "sitepress/compiler"
+  autoload :Model,                    "sitepress/model"
   autoload :RailsConfiguration,       "sitepress/rails_configuration"
   module Renderers
     autoload :Controller,             "sitepress/renderers/controller"

--- a/sitepress-rails/lib/sitepress/rails.rb
+++ b/sitepress-rails/lib/sitepress/rails.rb
@@ -19,8 +19,17 @@ module Sitepress
     autoload :DirectoryIndexPath,     "sitepress/build_paths/directory_index_path"
   end
 
+  # Base class for errors if Sitepress can't find a resource, model, etc.
+  NotFoundError = Class.new(StandardError)
+
   # Rescued by ActionController to display page not found error.
-  ResourceNotFound = Class.new(StandardError)
+  ResourceNotFoundError = Class.new(NotFoundError)
+  # Accidentally left out `Error` in the constant name, so I'm setting
+  # that up here for backwards compatability.
+  ResourceNotFound = ResourceNotFoundError
+
+  # Raised if a model isn't found.
+  ModelNotFoundError = Class.new(NotFoundError)
 
   # Raised when any of the Render subclasses can't render a page.
   RenderingError = Class.new(RuntimeError)

--- a/sitepress-rails/spec/sitepress/model_spec.rb
+++ b/sitepress-rails/spec/sitepress/model_spec.rb
@@ -1,0 +1,8 @@
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+
+describe Sitepress::Model do
+  let(:site) { Sitepress.site }
+  let(:build_path) { Pathname.new(Dir::tmpdir).join("build") }
+end


### PR DESCRIPTION
While building monoliths, I've found that its helpful to treat pages as data, particularly when they have front matter. In a current project I'm representing features as pages and front matter and want to query the collection like this from a slim template:

```ruby
ul
  - FeaturePage.all.select(&:paid).each do |feature|
    li= link_to_page feature
```

Here's what my feature pages look like:

```slim
---
title: Focus
subtitle: Read informative content without distraction
emoji: 🔭
layout: feature
tier: plus
order: 2
---

p Turn on focus and when you click on a Wikipedia link, we'll show you just the text so you can stay focused on reading and not get distracted by images, navigation, footers, donation requests (don't worry, we donate $1 of your subscription to Wikimedia), and all the other stuff that appears on Wikipedia pages.
```

Then my feature model looks like this:

```ruby
class FeaturePage < Sitepress::Model
  path "plus/*.html*"

  attr_data :title, :icon

  def paid?
    data["tier"] == "plus"
  end
end
```

My page models will all live in `./app/content/models`.

That's it! Now I can query my pages from anywhere in my site and link to them.

There's some more bells and whistles that I'd want like:
* `FeaturePage.find("plus")` should work. Need to have a finder that's derived from `path`
* Multiple scopes that go beyond the generic `FeaturePage.all`. Something like `FeaturePage.paid` could be useful as a DSL.
* Data validation via `attr_data :title, :icon, required: true`. An exception would be raised if the data is missing from that page.
* Default data via `attr_data :status, default: "unpublished"`. When a data attribute is missing from the front matter, this would set the value to the default.
