### PR TITLE
Fix for `Sitepress::Data#each` not returning result

### DIFF
--- a/sitepress-core/lib/sitepress/data.rb
+++ b/sitepress-core/lib/sitepress/data.rb
@@ -14,19 +14,14 @@ module Sitepress
     # Wraps an array and returns managed elements
     class Collection
       include Enumerable
+      extend Forwardable
+
+      def_delegators :@array, :each, :[]
 
       def initialize(array)
-        @array = array
-      end
-
-      def each
-        @array.each do |element|
+        @array = array.map do |element|
           Data.manage(element)
         end
-      end
-
-      def [](index)
-        Data.manage @array[index]
       end
     end
 

--- a/sitepress-core/spec/sitepress/data_spec.rb
+++ b/sitepress-core/spec/sitepress/data_spec.rb
@@ -89,6 +89,11 @@ context Sitepress::Data do
       ]
     end
     describe "Enumerable" do
+      it "iterates values" do
+        values = []
+        data.each { |v| values << v }
+        expect(values.count).to eq(4)
+      end
       it "returns values" do
         expect(data[0]).to eql("dogs")
         expect(data[1]).to eql(:cats)


### PR DESCRIPTION
This wraps the internal array on initialize then forwards the two methods directly to the array. But it does require "parsing" the array on initialize, not lazy like before.