### PR TITLE
Add `sort` keyword argument to `Sitepress::Model::collection`

### DIFF
--- a/sitepress-rails/lib/sitepress/models/collection.rb
+++ b/sitepress-rails/lib/sitepress/models/collection.rb
@@ -11,16 +11,19 @@ module Sitepress
       # Iterate over all resources in the site by default.
       DEFAULT_GLOB = "**/*.*".freeze
 
-      attr_reader :model, :glob, :site
+      attr_reader :model, :glob, :site, :sort
 
-      def initialize(model:, site:, glob: DEFAULT_GLOB)
+      def initialize(model:, site:, glob: DEFAULT_GLOB, sort: nil)
         @model = model
         @glob = glob
         @site = site
+        @sort = sort
       end
 
       def resources
-        site.glob glob
+        return unsorted_resources unless sort
+
+        unsorted_resources.sort_by { |resource| resource.data.try(:[], @sort) }
       end
 
       # Wraps each resource in a model object.
@@ -28,6 +31,12 @@ module Sitepress
         resources.each do |resource|
           yield model.new resource
         end
+      end
+
+      private
+
+      def unsorted_resources
+        site.glob(glob)
       end
     end
   end

--- a/sitepress-rails/spec/dummy/app/content/models/sort_model.rb
+++ b/sitepress-rails/spec/dummy/app/content/models/sort_model.rb
@@ -1,0 +1,4 @@
+class SortModel < Sitepress::Model
+  collection glob: "**/sort/*.html*", sort: :title
+  data :title
+end

--- a/sitepress-rails/spec/dummy/app/content/pages/sort/view_a.html.erb
+++ b/sitepress-rails/spec/dummy/app/content/pages/sort/view_a.html.erb
@@ -1,0 +1,5 @@
+---
+title: Z Title
+---
+
+This page alphabetically appears first, but has a title starting with Z

--- a/sitepress-rails/spec/dummy/app/content/pages/sort/view_z.html.erb
+++ b/sitepress-rails/spec/dummy/app/content/pages/sort/view_z.html.erb
@@ -1,0 +1,5 @@
+---
+title: A Title
+---
+
+This page alphabetically appears last, but has a title starting with A

--- a/sitepress-rails/spec/sitepress/compiler_spec.rb
+++ b/sitepress-rails/spec/sitepress/compiler_spec.rb
@@ -13,7 +13,7 @@ describe Sitepress::Compiler::Files do
     after { FileUtils.rm_rf(build_path) }
     it "writes files to build_path" do
       subject.compile
-      expect(Dir.glob(build_path.join("**")).size).to eql(3) # 2 items in the site... mkay?
+      expect(Dir.glob(build_path.join("**")).size).to eql(4) # 3 items in the site... mkay?
     end
   end
 end

--- a/sitepress-rails/spec/sitepress/model_sort_spec.rb
+++ b/sitepress-rails/spec/sitepress/model_sort_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+
+describe Sitepress::Model do
+  let(:model) { SortModel }
+
+  describe "#all" do
+    subject { model.all.to_a }
+
+    it "sorts collection alphabecitally by given symbol" do
+      expect(subject.count).to(eql(2))
+
+      expect(subject.first.title).to(eql("A Title"))
+      expect(subject.second.title).to(eql("Z Title"))
+
+      expect(subject.second).to(eql(subject.last))
+    end
+  end
+end

--- a/sitepress-rails/spec/sitepress/model_spec.rb
+++ b/sitepress-rails/spec/sitepress/model_spec.rb
@@ -9,7 +9,7 @@ describe Sitepress::Model do
     subject { model.all }
     context "models" do
       it "has correct count" do
-        expect(subject.count).to eql 3
+        expect(subject.count).to eql 5
       end
       it "is instances of model" do
         expect(subject.first).to be_instance_of PageModel
@@ -18,7 +18,7 @@ describe Sitepress::Model do
     describe "#resources" do
       subject { model.all.resources }
       it "has correct count" do
-        expect(subject.count).to eql 3
+        expect(subject.count).to eql 5
       end
       it "is instances of pages" do
         expect(subject.first).to be_instance_of Sitepress::Resource


### PR DESCRIPTION
Hey there 👋🏼  Thanks for Sitepress, I use it in [hotwire.io](https://github.com/marcoroth/hotwire.io) and I'm happy so far!

I found myself calling `SomeModel.all.sort_by { |page| page.data.fetch("key") }` more than I would have liked, and thought: "why isn't there a way to tell the model on how it should sort it's resources".

This is why this pull request adds a `sort` keyword argument to the `Sitepress::Model::collection` method, so you can define a model and always get it's resources sorted:

```ruby
class PersonPage < Sitepress::Model
  collection glob: "people/*.html*", sort: :title
  data :name, :title, :email
end
```

While this implementation works, I feel like it could be even more advanced, like sort order (`:asc`, `:desc`) or reyling on instance methods on the `Model` itself, instead of just relying on `resource.data`.

But before I continue to work on it I wanted to see if there's any interest from your side to explore anything in this direction, or if there's anything I'm missing which would make this whole feature obsolete.

Thank you!