### PR TITLE
Base mobile support.

### DIFF
--- a/sitepress-cli/templates/default/assets/stylesheets/site.css.scss
+++ b/sitepress-cli/templates/default/assets/stylesheets/site.css.scss
@@ -5,7 +5,7 @@ body {
   background: #fefefe;
   max-width: 40rem;
   margin: 0 auto;
-  padding: 4rem;
+  padding: 1rem;
   line-height: 1.5rem;
 }
 
@@ -27,10 +27,6 @@ header {
 
 .logo-dark {
   display: none;
-}
-
-#title {
-  margin-left: 1rem;
 }
 
 footer {

--- a/sitepress-cli/templates/default/layouts/layout.html.erb
+++ b/sitepress-cli/templates/default/layouts/layout.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><%= current_page.data.fetch("title", "Sitepress") %></title>
     <%= stylesheet_link_tag "site" %>
   </head>


### PR DESCRIPTION
Use meta tag to allow scaling proportions on mobile (tried with iPhone/iPad). 
Remove left margin on #title to Avoid breaking it on two lines.

![immagine](https://github.com/sitepress/sitepress/assets/92588/48368056-917a-43f2-810e-9a2df92d12ee)
