### PR TITLE
fix(sitepress-cli): lock rack version to 2.2.9 in the CLI to prevent name errors

### DIFF
--- a/sitepress-cli/sitepress-cli.gemspec
+++ b/sitepress-cli/sitepress-cli.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "thor", ">= 1.0.0"
-  spec.add_runtime_dependency "rack", ">= 1.0.0"
+  spec.add_runtime_dependency "rack", ">= 1.0.0", "<= 2.2.9"
   spec.add_runtime_dependency "sitepress-server", spec.version
 end

--- a/sitepress-cli/spec/sitepress/cli_spec.rb
+++ b/sitepress-cli/spec/sitepress/cli_spec.rb
@@ -1,17 +1,34 @@
 require "spec_helper"
+require "rack"
 
-# TODO: Figure out hte best way to test the dang Thor cli and
-# test that the classes are recieving the right messages.
+Sitepress::Server = Class.new
+
 describe Sitepress::CLI do
-  subject { Sitepress::CLI.start(args) }
-  context "#server" do
-    let(:args) { %w[-c spec/sites/sample/site.rb -p 5000 -b 127.0.0.1] }
-    it "calls server"
+  let(:cli) { Sitepress::CLI.new }
+  let(:app) { double("app", config: double("config", enable_site_error_reporting: nil, enable_site_reloading: nil)) }
+
+  describe "#server" do
+    let(:options) { { "port" => 3000, "bind_address" => "0.0.0.0", "site_reloading" => true, "site_error_reporting" => true } }
+
+    before do
+      allow(cli).to receive(:options).and_return(options)
+      allow(cli).to receive(:initialize!).and_yield(app)
+      allow(Rack::Server).to receive(:start)
+    end
+
+    it "runs the preview server with the correct options" do
+      allow(app.config).to receive(:enable_site_error_reporting=).with(true)
+      allow(app.config).to receive(:enable_site_reloading=).with(true)
+      expect(Rack::Server).to receive(:start).with(hash_including(app: Sitepress::Server, Port: 3000, Host: "0.0.0.0"))
+      cli.server
+    end
   end
+
   context "#compile" do
     let(:args) { %w[-c spec/sites/sample/site.rb -o spec/sites/sample/build] }
     it "calls compiler"
   end
+
   context "#new" do
     let(:args) { %w[-t default spec/sites/new_site] }
     it "calls new"

--- a/sitepress-core/lib/sitepress/version.rb
+++ b/sitepress-core/lib/sitepress/version.rb
@@ -1,3 +1,3 @@
 module Sitepress
-  VERSION = "4.0.2".freeze
+  VERSION = "4.0.3".freeze
 end


### PR DESCRIPTION
Currently, when starting a web server for newly created sites from the CLI, the server fails to start. Rack is being bundled in newer versions (e.g., 3.1.3), and it appears that the `Rack::Server` class is now [deprecated](https://github.com/rack/rackup/blob/eaea24a3d64a1b117df943a9d06779e659bb61af/lib/rack/server.rb#L6).

This PR sets the rack version of the `sitepress-cli` gem to a range from `1.0.0` to `2.2.9` to avoid errors before the whole project is ready to be migrated to rack 3.

## Steps to reproduce

```
$ ruby -v
ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [arm64-darwin21]
```

```
$ gem install sitepress
Fetching sitepress-4.0.2.gem
Fetching sitepress-core-4.0.2.gem
Fetching sitepress-rails-4.0.2.gem
Fetching sitepress-server-4.0.2.gem
Fetching sitepress-cli-4.0.2.gem
Successfully installed sitepress-core-4.0.2
Successfully installed sitepress-rails-4.0.2
Successfully installed sitepress-server-4.0.2
Successfully installed sitepress-cli-4.0.2
Successfully installed sitepress-4.0.2
Parsing documentation for sitepress-core-4.0.2
Installing ri documentation for sitepress-core-4.0.2
Parsing documentation for sitepress-rails-4.0.2
Installing ri documentation for sitepress-rails-4.0.2
Parsing documentation for sitepress-server-4.0.2
Installing ri documentation for sitepress-server-4.0.2
Parsing documentation for sitepress-cli-4.0.2
Installing ri documentation for sitepress-cli-4.0.2
Parsing documentation for sitepress-4.0.2
Installing ri documentation for sitepress-4.0.2
Done installing documentation for sitepress-core, sitepress-rails, sitepress-server, sitepress-cli, sitepress after 0 seconds
5 gems installed
```

```
$ rbenv rehash
$ sitepress new ~/Workspace/site
$ cd ~/Workspace/site && bundle install
$ bundle exec sitepress server
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
 (called from load at /Users/user/.rbenv/versions/3.1.0/bin/sitepress:25)
bundler: failed to load command: sitepress (/Users/user/.rbenv/versions/3.1.0/bin/sitepress)
/Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/sitepress-cli-4.0.2/lib/sitepress/cli.rb:45:in `server': uninitialized constant Rack::Server (NameError)

      Rack::Server.start app: app,
          ^^^^^^^^
Did you mean?  TCPServer
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/thor-1.3.1/lib/thor.rb:527:in `dispatch'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/thor-1.3.1/lib/thor/base.rb:584:in `start'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/sitepress-4.0.2/exe/sitepress:5:in `<top (required)>'
  from /Users/user/.rbenv/versions/3.1.0/bin/sitepress:25:in `load'
  from /Users/user/.rbenv/versions/3.1.0/bin/sitepress:25:in `<top (required)>'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `load'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:58:in `kernel_load'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/cli/exec.rb:23:in `run'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/cli.rb:486:in `exec'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/cli.rb:31:in `dispatch'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/cli.rb:25:in `start'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/exe/bundle:48:in `block in <top (required)>'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
  from /Users/user/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/bundler-2.3.26/exe/bundle:36:in `<top (required)>'
  from /Users/user/.rbenv/versions/3.1.0/bin/bundle:25:in `load'
  from /Users/user/.rbenv/versions/3.1.0/bin/bundle:25:in `<main>'
  ```