### PR TITLE
Use to_prepare for initialization of handler_extensions

### DIFF
--- a/sitepress-rails/lib/sitepress/engine.rb
+++ b/sitepress-rails/lib/sitepress/engine.rb
@@ -54,11 +54,8 @@ module Sitepress
         app.config.cache_classes
       end
 
-      # Setup Sitepress to handle Rails extensions.
-      ActiveSupport.on_load(:action_view) do
-        ActiveSupport.on_load(:after_initialize) do
-          Sitepress::Path.handler_extensions = ActionView::Template::Handlers.extensions
-        end
+      config.to_prepare do
+        Sitepress::Path.handler_extensions = ActionView::Template::Handlers.extensions
       end
     end
 


### PR DESCRIPTION
Hi @bradgessler, just wanted to open this PR based off of @rossta's identification of the problem described here: https://github.com/sitepress/sitepress/issues/64

TL;DR -- Previous usage of initialization caused issues in development with Rails 8.x

Currently I've tested it in local dev and it _seems_ to work (but the problem is sporadic and depends on the load order of the app). Works in production (which was never broken anyway, just development envs).

Send feedback. I'd be happy to modify/amend/close PR :-)

Credits: @rossta for tracing the root cause.