### PR TITLE
Rails 8 fix for `_layout` call signature breaks on 8.0.0 and 8.0.1

### DIFF
--- a/sitepress-rails/rails/app/controllers/concerns/sitepress/site_pages.rb
+++ b/sitepress-rails/rails/app/controllers/concerns/sitepress/site_pages.rb
@@ -125,8 +125,8 @@ module Sitepress
     # For whatever reason, Rails can't stablize this API so we need to check
     # the version of Rails to make the right call and stablize it.
     def find_layout(formats:)
-      case Rails::VERSION::MAJOR
-      when 8
+      case Rails::VERSION
+      when -> (rails_version) { rails_version::MAJOR > 8 || rails_version::MAJOR == 8 && rails_version::MINOR > 1 }
         _layout(lookup_context, formats, lookup_context.prefixes)
       else
         _layout(lookup_context, formats)


### PR DESCRIPTION
Hi there, thanks a lot for sitepress!

The `_layout` call in Rails 8.0.0 and 8.0.1 still uses the old signature and thus for those versions this gem is broken. 
Just came across this:

```
ArgumentError in Sitepress::SiteController#show
wrong number of arguments (given 3, expected 2)

sitepress (e563add7c3a8) sitepress-rails/rails/app/controllers/concerns/sitepress/site_pages.rb:129:in `block in find_layout'
sitepress (e563add7c3a8) sitepress-rails/rails/app/controllers/concerns/sitepress/site_pages.rb:129:in `find_layout'
sitepress (e563add7c3a8) sitepress-rails/rails/app/controllers/concerns/sitepress/site_pages.rb:116:in `block in resource_layout'
sitepress (e563add7c3a8) sitepress-core/lib/sitepress/data.rb:51:in `fetch'
sitepress (e563add7c3a8) sitepress-core/lib/sitepress/data.rb:51:in `fetch'
sitepress (e563add7c3a8) sitepress-rails/rails/app/controllers/concerns/sitepress/site_pages.rb:115:in `resource_layout'
sitepress (e563add7c3a8) sitepress-rails/rails/app/controllers/concerns/sitepress/site_pages.rb:51:in `render_resource_with_handler'
sitepress (e563add7c3a8) sitepress-rails/rails/app/controllers/concerns/sitepress/site_pages.rb:40:in `render_resource'
sitepress (e563add7c3a8) sitepress-rails/rails/app/controllers/concerns/sitepress/site_pages.rb:27:in `show'
```

This fix should take care of that. Closes #72 