### PR TITLE
Update markdown-rails to 2.0 in gemfile template

### DIFF
--- a/sitepress-cli/templates/default/Gemfile.tt
+++ b/sitepress-cli/templates/default/Gemfile.tt
@@ -11,7 +11,7 @@ gem "webrick"
 gem "haml-rails"
 gem "slim-rails"
 gem "sass-rails"
-gem "markdown-rails", "~> 1.0"
+gem "markdown-rails", "~> 2.0"
 
 # View component libraries.
 gem "phlex-rails"


### PR DESCRIPTION
When creating a new Sitepress site using `sitepress new` the `markdown-rails` version is wrong leading to confusion when attempting to create application renderers based on the website's documentation.